### PR TITLE
update to better utilize the underlying fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,5 @@ This converts to
 ```
 
 and is stored in the `content_json` field.
+
+In this example ensure that the `content_json` field is being set to cast to `object` on the underlying model instance.

--- a/resources/js/mixins/HasChildFields.js
+++ b/resources/js/mixins/HasChildFields.js
@@ -8,21 +8,6 @@ export default {
   },
 
   created() {
-    this.fields = this.field.fields.map(field => {
-      let value = '';
-      let jsonValue = this.field.value;
-      if(typeof jsonValue === 'object') {
-          jsonValue = JSON.stringify(jsonValue) || '{}';
-      }
-      jsonValue = Object.assign({}, JSON.parse(jsonValue)) || {};
-      if (field.attribute in jsonValue) {
-        value = jsonValue[field.attribute];
-      }
-
-      return {
-        ...field,
-        value
-      };
-    });
+    this.fields = this.field.fields;
   }
 };

--- a/src/Json.php
+++ b/src/Json.php
@@ -55,7 +55,9 @@ class Json extends Field
     {
         $attribute = $attribute ?? $this->attribute;
 
-        $this->value = json_decode($resource->{$attribute});
+        $value = $resource->{$attribute};
+
+        $this->value = is_object($value) ? $value : json_decode($value);
 
         $this->fields->whereInstanceOf(Resolvable::class)->each->resolve($this->value);
 

--- a/src/Json.php
+++ b/src/Json.php
@@ -3,6 +3,8 @@
 namespace R64\NovaJson;
 
 use Laravel\Nova\Fields\Field;
+use Laravel\Nova\Contracts\Resolvable;
+use Laravel\Nova\Http\Requests\NovaRequest;
 
 class Json extends Field
 {
@@ -39,6 +41,46 @@ class Json extends Field
     {
         parent::__construct($name, $attribute, $resolveCallback);
 
-        $this->withMeta(['fields' => $fields]);
+        $this->fields = collect($fields);
+    }
+
+    /**
+     * Resolve the field's value.
+     *
+     * @param  mixed  $resource
+     * @param  string|null  $attribute
+     * @return void
+     */
+    public function resolve($resource, $attribute = null)
+    {
+        $attribute = $attribute ?? $this->attribute;
+
+        $this->value = json_decode($resource->{$attribute});
+
+        $this->fields->whereInstanceOf(Resolvable::class)->each->resolve($this->value);
+
+        $this->withMeta(['fields' => $this->fields]);
+
+        parent::resolve($resource, $attribute);
+    }
+
+    /**
+     * Hydrate the given attribute on the model based on the incoming request.
+     *
+     * @param  \Laravel\Nova\Http\Requests\NovaRequest  $request
+     * @param  string  $requestAttribute
+     * @param  object  $model
+     * @param  string  $attribute
+     * @return void
+     */
+    protected function fillAttributeFromRequest(NovaRequest $request, $requestAttribute, $model, $attribute)
+    {
+        $request->merge([
+            $requestAttribute => json_decode($request[$requestAttribute], true)
+        ]);
+
+        $this->fields->each(function ($field) use ($request, $model, $attribute) {
+            $field->fillInto($request, $model, $attribute.'->'.$field->attribute, $attribute.'.'.$field->attribute);
+        });
     }
 }


### PR DESCRIPTION
After attempting to add custom resolving logic to a field inside the json field, I noticed that didn't get applied. This PR should enable mostly any backend customization or custom filling of internal attributes into a json string for storage into the db.

note...writing JS is not quite by strong suit so if something's in the wrong place or could be put elsewhere (random object prototype for example) please let me know 